### PR TITLE
Avoid allocation when :prefix_delimiter isn't set

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -231,7 +231,11 @@ But it was #{server}.
   # Return the current prefix key.
   def prefix_key
     if @struct.prefix_key.size > 0
-      @struct.prefix_key[0..-1 - options[:prefix_delimiter].size]
+      if options[:prefix_delimiter]
+        @struct.prefix_key[0..-1 - options[:prefix_delimiter].size]
+      else
+        @struct.prefix_key
+      end
     else
       ""
     end

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -231,7 +231,7 @@ But it was #{server}.
   # Return the current prefix key.
   def prefix_key
     if @struct.prefix_key.size > 0
-      if options[:prefix_delimiter]
+      if options[:prefix_delimiter].size > 0
         @struct.prefix_key[0..-1 - options[:prefix_delimiter].size]
       else
         @struct.prefix_key


### PR DESCRIPTION
```ruby
@struct.prefix_key[0..-1 - options[:prefix_delimiter].size]
```

Every call to `prefix_key` allocates a String when `@struct.prefix_key.size > 0`. This is only necessary when `options[:prefix_prefix_delimiter]` is set. Otherwise, we can avoid the allocation by simply returning `@struct.prefix_key`.